### PR TITLE
feat: Integrate main portal and restructure LiteWebServer

### DIFF
--- a/litewebserver/litewebserver.py
+++ b/litewebserver/litewebserver.py
@@ -35,6 +35,13 @@ def get_path_details(base_path, subpath=""):
 
 # --- Routes ---
 @app.route('/')
+def main_portal():
+    return render_template('main_portal.html')
+
+@app.route('/scheduler_graph_tool/')
+def serve_scheduler_graph():
+    return render_template('scheduler_graph.html')
+
 @app.route('/browse/')
 @app.route('/browse/<path:subpath>')
 def browse_files(subpath=""):

--- a/litewebserver/templates/main_portal.html
+++ b/litewebserver/templates/main_portal.html
@@ -1,0 +1,216 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>RTOS V2X 智能运维原子能力验证平台 - 主页</title>
+    <!-- 引入 Tailwind CSS 以实现现代化、响应式的设计 -->
+    <script src="https://cdn.tailwindcss.com"></script>
+    <!-- 引入 Google Fonts 的 Inter 字体 -->
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+    <style>
+        /* 使用 Inter 字体作为基础字体 */
+        body {{
+            font-family: 'Inter', sans-serif;
+            -webkit-font-smoothing: antialiased;
+            -moz-osx-font-smoothing: grayscale;
+        }}
+        /* 为卡片添加一个微妙的过渡效果和阴影增强 */
+        .feature-card {{
+            transition: transform 0.3s ease, box-shadow 0.3s ease;
+        }}
+        .feature-card:hover {{
+            transform: translateY(-8px);
+            box-shadow: 0 20px 25px -5px rgb(0 0 0 / 0.1), 0 8px 10px -6px rgb(0 0 0 / 0.1);
+        }}
+    </style>
+</head>
+<body class="bg-slate-100 text-slate-800">
+
+    <div class="container mx-auto px-6 py-12 md:py-20">
+
+        <!-- 平台标题和描述 -->
+        <header class="text-center mb-12 md:mb-16">
+            <h1 class="text-4xl md:text-5xl font-bold text-slate-900 -mt-9">
+                <span class="text-indigo-600">RTOS V2X</span>智能运维平台<span class="text-indigo-600">原子能力验证中心</span>
+            </h1>
+            <p class="mt-4 text-lg md:text-xl text-slate-600 max-w-3xl mx-auto">
+                仅用于<a href="https://rtosdfx.rnd.huawei.com/application/" class="text-indigo-600 hover:underline">[内部运维功能]</a> <a href="http://rtosdfx.rnd.huawei.com:8888/tree" class="text-indigo-600 hover:underline">[穿刺预研]</a>，正式平台为<a href="https://fireeye.rnd.huawei.com/fireeye/toolbox" class="text-indigo-600 hover:underline">[RTOS运维平台]</a>
+            </p>
+			<p class="mt-4 text-lg md:text-xl text-slate-600 max-w-3xl mx-auto">
+			<a href="https://wiki.huawei.com/domains/12565/wiki/179215/WIKI202501075661690" class="text-indigo-600 hover:underline">[RTOS V2X DFX先锋队出品]</a>
+			</p>
+
+        </header>
+
+     <!-- 功能模块网格布局 (已按新顺序排列) -->
+    <main class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-8">
+
+        <!-- 卡片 1: 性能瓶颈分析 -->
+        <a href="https://fireeye.rnd.huawei.com/fireeye/parse/result?bizType=perf_analysis" target="_blank" class="feature-card block bg-white p-6 rounded-xl shadow-lg border border-slate-200">
+            <div class="flex items-center">
+                <div class="flex-shrink-0 flex items-center justify-center h-16 w-16 rounded-full bg-indigo-100 mr-4">
+                    <!-- SVG 图标: 仪表盘 -->
+                    <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="text-indigo-600">
+                        <path d="m12 14 4-4"/>
+                        <path d="M3.34 19a10 10 0 1 1 17.32 0"/>
+                    </svg>
+                </div>
+                <h2 class="text-xl font-bold text-slate-900">性能瓶颈分析</h2>
+            </div>
+            <p class="text-slate-600 leading-relaxed mt-4">
+                从系统级到符号级逐层下钻，精准分析高频函数与调度切换，定位性能瓶颈
+            </p>
+        </a>
+
+        <!-- 卡片 2: 微架构分析 -->
+        <a href="http://rtosdfx.rnd.huawei.com:8888/view/performance_spe_analyzer/topdown_microarchitecture_analysis_report.html" target="_blank" class="feature-card block bg-white p-6 rounded-xl shadow-lg border border-slate-200">
+            <div class="flex items-center">
+                <div class="flex-shrink-0 flex items-center justify-center h-16 w-16 rounded-full bg-pink-100 mr-4">
+                    <!-- SVG 图标: 微架构/芯片 -->
+                    <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="text-pink-600"><rect x="5" y="5" width="14" height="14" rx="2" /><path d="M9 9h6v6H9z" /><path d="M9 1v4" /><path d="M15 1v4" /><path d="M9 23v-4" /><path d="M15 23v-4" /><path d="M1 9h4" /><path d="M1 15h4" /><path d="M23 9h-4" /><path d="M23 15h-4" /></svg>
+                </div>
+                <h2 class="text-xl font-bold text-slate-900">微架构分析</h2>
+            </div>
+            <p class="text-slate-600 leading-relaxed mt-4">
+                深入CPU微架构，分析缓存命中率、指令流水线等关键硬件性能指标
+            </p>
+        </a>
+
+        <!-- 卡片 3: 调度关系力导向图 -->
+        <a href="{{ url_for('serve_scheduler_graph') }}" target="_blank" class="feature-card block bg-white p-6 rounded-xl shadow-lg border border-slate-200">
+            <div class="flex items-center">
+                 <div class="flex-shrink-0 flex items-center justify-center h-16 w-16 rounded-full bg-purple-100 mr-4">
+                    <!-- SVG 图标: 调度/分支 -->
+                    <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="text-purple-600"><path d="M6 3v12"/><path d="M18 9a3 3 0 1 0 0-6 3 3 0 0 0 0 6z"/><path d="M6 21a3 3 0 1 0 0-6 3 3 0 0 0 0 6z"/><path d="M18 21a3 3 0 1 0 0-6 3 3 0 0 0 0 6z"/><path d="M6 15V9a3 3 0 0 1 3-3h6a3 3 0 0 1 3 3v6a3 3 0 0 1-3 3H9a3 3 0 0 1-3-3z"/></svg>
+                </div>
+                <h2 class="text-xl font-bold text-slate-900">调度关系力导向图</h2>
+            </div>
+            <p class="text-slate-600 leading-relaxed mt-4">
+                力导向算法实现强链接线程(切换频繁)聚合成紧密集群，指导线程合并/绑核
+            </p>
+        </a>
+
+        <!-- 卡片 4: 调度轨迹分析 -->
+        <a href="https://fireeye.rnd.huawei.com/fireeye/parse/result?bizType=sched_analysis" target="_blank" class="feature-card block bg-white p-6 rounded-xl shadow-lg border border-slate-200">
+            <div class="flex items-center">
+                <div class="flex-shrink-0 flex items-center justify-center h-16 w-16 rounded-full bg-purple-100 mr-4">
+                    <!-- SVG 图标: 调度/分支 -->
+                    <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="text-purple-600"><path d="M6 3v12"/><path d="M18 9a3 3 0 1 0 0-6 3 3 0 0 0 0 6z"/><path d="M6 21a3 3 0 1 0 0-6 3 3 0 0 0 0 6z"/><path d="M18 21a3 3 0 1 0 0-6 3 3 0 0 0 0 6z"/><path d="M6 15V9a3 3 0 0 1 3-3h6a3 3 0 0 1 3 3v6a3 3 0 0 1-3 3H9a3 3 0 0 1-3-3z"/></svg>
+                </div>
+                <h2 class="text-xl font-bold text-slate-900">调度轨迹分析</h2>
+            </div>
+            <p class="text-slate-600 leading-relaxed mt-4">
+                精细化追踪线程调度过程，识别抢占、阻塞点，提升系统并发效率。
+            </p>
+        </a>
+
+        <!-- 卡片 5: 中断轨迹分析 -->
+        <a href="https://fireeye.rnd.huawei.com/fireeye/parse/result?bizType=irqtrace_analysis" target="_blank" class="feature-card block bg-white p-6 rounded-xl shadow-lg border border-slate-200">
+            <div class="flex items-center">
+                <div class="flex-shrink-0 flex items-center justify-center h-16 w-16 rounded-full bg-amber-100 mr-4">
+                    <!-- SVG 图标: 中断/闪电 -->
+                    <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="text-amber-600"><polygon points="13 2 3 14 12 14 11 22 21 10 12 10 13 2"></polygon></svg>
+                </div>
+                <h2 class="text-xl font-bold text-slate-900">中断轨迹分析</h2>
+            </div>
+            <p class="text-slate-600 leading-relaxed mt-4">
+                可视化中断响应流程，分析中断延迟与频率，优化系统实时性。
+            </p>
+        </a>
+
+        <!-- 卡片 6: 启动时序建模 -->
+        <a href="https://fireeye.rnd.huawei.com/fireeye/parse/result?bizType=fast_start_timing" target="_blank" class="feature-card block bg-white p-6 rounded-xl shadow-lg border border-slate-200">
+            <div class="flex items-center">
+                <div class="flex-shrink-0 flex items-center justify-center h-16 w-16 rounded-full bg-sky-100 mr-4">
+                    <!-- SVG 图标: 火箭/启动 -->
+                    <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="text-sky-600"><path d="M4.5 16.5c-1.5 1.26-2 5-2 5s3.74-.5 5-2c.71-.84.7-2.3.5-3.5-1.17-1.17-2.65-.84-3.5-.5Z"/><path d="m12 15.5 3.5-3.5C12.84 9.36 12.5 6.5 15 4c.66-.66 1.5-1 2.5-1s1.84.34 2.5 1c2.5 2.5 1.36 5.16-1.5 7.84l-3.5 3.5"/><path d="m20 21-1.5-1.5"/><path d="M17 18a2 2 0 0 0-2-2"/><path d="m15 13-3.5-3.5"/></svg>
+                </div>
+                <h2 class="text-xl font-bold text-slate-900">启动时序建模</h2>
+            </div>
+            <p class="text-slate-600 leading-relaxed mt-4">
+                通过时序火焰图和差分分析，可视化启动流程，快速发现性能退化与优化点。
+            </p>
+        </a>
+
+        <!-- 卡片 7: 内存小型化分析 -->
+        <a href="https://fireeye.rnd.huawei.com/fireeye/parse/result?bizType=memory_analysis" target="_blank" class="feature-card block bg-white p-6 rounded-xl shadow-lg border border-slate-200">
+            <div class="flex items-center">
+                 <div class="flex-shrink-0 flex items-center justify-center h-16 w-16 rounded-full bg-emerald-100 mr-4">
+                    <!-- SVG 图标: 内存/芯片 -->
+                    <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="text-emerald-600"><rect width="18" height="18" x="3" y="3" rx="2"/><path d="M7 7h4"/><path d="M7 12h4"/><path d="M7 17h4"/><path d="M15 7h1"/><path d="M15 12h1"/><path d="M15 17h1"/></svg>
+                </div>
+                <h2 class="text-xl font-bold text-slate-900">内存小型化分析</h2>
+            </div>
+            <p class="text-slate-600 leading-relaxed mt-4">
+                覆盖全局、业务进程与OS底噪的精细化分析，全面洞悉动静态内存开销与分布。
+            </p>
+        </a>
+
+        <!-- 卡片 8: 异常日志辅助定位 -->
+        <a href="https://rtosdfx.rnd.huawei.com/application/" target="_blank" class="feature-card block bg-white p-6 rounded-xl shadow-lg border border-slate-200">
+            <div class="flex items-center">
+                <div class="flex-shrink-0 flex items-center justify-center h-16 w-16 rounded-full bg-rose-100 mr-4">
+                    <!-- SVG 图标: 搜索/诊断 -->
+                    <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="text-rose-600"><path d="m8 6 4-4 4 4"/><path d="M12 2v10.3a4 4 0 0 1-1.172 2.872L4 22"/><path d="m20 22-5-5"/><path d="M16 13.3a4 4 0 0 0 1.172-2.872V2"/></svg>
+                </div>
+                <h2 class="text-xl font-bold text-slate-900">异常日志辅助定位</h2>
+            </div>
+            <p class="text-slate-600 leading-relaxed mt-4">
+                利用日志泳道图聚合上下文，结合AI辅助诊断，高效识别异常模式与根因。
+            </p>
+        </a>
+
+        <!-- 卡片 9: DFX 平台数据文件浏览器 -->
+        <a href="{{ url_for('browse_files') }}" target="_blank" class="feature-card block bg-white p-6 rounded-xl shadow-lg border border-slate-200">
+            <div class="flex items-center">
+                <div class="flex-shrink-0 flex items-center justify-center h-16 w-16 rounded-full bg-teal-100 mr-4">
+                    <!-- SVG 图标: 文件夹 -->
+                    <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="text-teal-600">
+                        <path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z"></path>
+                    </svg>
+                </div>
+                <h2 class="text-xl font-bold text-slate-900">DFX数据浏览器</h2>
+            </div>
+            <p class="text-slate-600 leading-relaxed mt-4">
+                在线浏览、上传、搜索DFX平台后台数据文件，提供便捷的文件操作
+            </p>
+        </a>
+
+    </main>
+
+        <!-- 用于展示可扩展性的占位符 -->
+        <footer class="text-center mt-12 md:mt-20 pt-8 border-t border-slate-200">
+             <p class="text-slate-500">未来更多功能模块将在此处呈现。</p>
+        </footer>
+
+    </div>
+
+    <!-- 新增脚本: 强制在新窗口中打开所有链接 -->
+    <script>
+        document.addEventListener('DOMContentLoaded', function() {{
+            // 选择页面中所有的 <a> 标签
+            const allLinks = document.querySelectorAll('a');
+
+            allLinks.forEach(link => {{
+                // 为每个链接添加点击事件监听器
+                link.addEventListener('click', function(event) {{
+                    // 1. 阻止链接的默认跳转行为
+                    event.preventDefault();
+
+                    // 2. 获取链接的 href 属性值
+                    const url = this.getAttribute('href');
+
+                    // 3. 确保URL存在，然后使用 window.open 在新窗口中打开
+                    if (url) {{
+                        window.open(url, '_blank');
+                    }}
+                }});
+            }});
+        }});
+    </script>
+
+</body>
+</html>

--- a/litewebserver/templates/scheduler_graph.html
+++ b/litewebserver/templates/scheduler_graph.html
@@ -1,0 +1,383 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Scheduler Trace Visualizer</title>
+    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <style>
+        /* Custom styles to complement Tailwind */
+        body {{
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            background-color: #f8f9fa;
+        }}
+
+        .metric-card {{
+            background-color: white;
+            border-radius: 0.75rem;
+            box-shadow: 0 4px 6px -1px rgb(0 0 0 / 0.1), 0 2px 4px -2px rgb(0 0 0 / 0.1);
+        }}
+
+        #graph-container {{
+            flex-grow: 1;
+            position: relative;
+            cursor: move;
+        }}
+
+        svg {{
+            width: 100%;
+            height: 100%;
+            display: block;
+        }}
+
+        .node, .link-group {{
+            cursor: pointer;
+        }}
+
+        #tooltip {{
+            position: absolute;
+            background-color: rgba(0, 0, 0, 0.8);
+            color: white;
+            padding: 6px 10px;
+            border-radius: 4px;
+            font-size: 0.85rem;
+            pointer-events: none;
+            opacity: 0;
+            transition: opacity 0.2s;
+        }}
+    </style>
+</head>
+<body>
+
+    <div class="flex flex-col h-screen w-full p-4 md:p-6 lg:p-8 bg-gray-50">
+        <!-- Compact Control Bar -->
+		<h1 class="text-3xl font-bold text-gray-800 mb-6 text-center">RTOS V2X Scheduler Trace Graph Visualizer</h1>
+        <div class="metric-card p-3 mb-4">
+             <div class="flex flex-wrap items-center gap-x-4 gap-y-2">
+                 <!-- File Input -->
+                 <div class="flex items-center">
+                    <input type="file" id="fileInput" accept=".txt,.log" class="block w-full text-sm text-gray-500
+                        file:mr-3 file:py-1.5 file:px-3
+                        file:rounded-full file:border-0 file:text-sm file:font-semibold
+                        file:bg-indigo-50 file:text-indigo-700 hover:file:bg-indigo-100"/>
+                 </div>
+				 <!-- Metrics -->
+                 <div class="flex items-center space-x-4 text-sm">
+                    <div class="flex items-baseline space-x-1.5">
+                        <span class="font-semibold text-gray-600">仅支持V2X调度轨迹数据格式
+						<a href="https://3ms.huawei.com/next/groups/index.html#/wiki/detail?groupId=3828267&wikiId=6571498" class="text-indigo-600 hover:underline">[思路来源] </a>
+						<a href="https://wiki.huawei.com/domains/12565/wiki/179215/WIKI202501105697774" class="text-indigo-600 hover:underline">[调度数据采集]</a>
+						</span>
+                    </div>
+                 </div>
+                 <!-- Analyze Button -->
+                 <button id="analyzeBtn" class="px-5 py-1.5 bg-indigo-600 text-white text-sm font-semibold rounded-lg shadow-md hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-opacity-75">Analyze</button>
+
+                 <div class="h-6 border-l border-gray-300 mx-2"></div>
+
+                 <!-- Metrics -->
+                 <div class="flex items-center space-x-4 text-sm">
+                    <div class="flex items-baseline space-x-1.5">
+                        <span class="font-semibold text-gray-600">Nodes:</span>
+                        <p id="total-nodes" class="font-bold text-indigo-600">-</p>
+                    </div>
+                    <div class="flex items-baseline space-x-1.5">
+                        <span class="font-semibold text-gray-600">Edges:</span>
+                        <p id="total-edges" class="font-bold text-indigo-600">-</p>
+                    </div>
+                     <div class="flex items-baseline space-x-1.5">
+                        <span class="font-semibold text-gray-600">Switches:</span>
+                        <p id="total-switches" class="font-bold text-indigo-600">-</p>
+                    </div>
+                 </div>
+
+                <div class="h-6 border-l border-gray-300 mx-2"></div>
+
+                 <!-- Graph Controls -->
+                <div id="graph-controls" class="hidden items-center space-x-2">
+                    <label for="weightThreshold" class="text-sm font-medium text-gray-700 whitespace-nowrap">最小调度次数:</label>
+                    <input type="number" id="weightThreshold" value="1" min="1" class="w-20 p-1.5 rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm">
+                </div>
+             </div>
+        </div>
+
+        <!-- Chart Section -->
+        <div class="metric-card flex-grow flex flex-col">
+            <div id="graph-container" class="flex-grow flex flex-col relative">
+                 <div id="placeholder" class="text-center text-gray-500 flex items-center justify-center h-full">
+                    Please upload your trace data file to begin analysis.
+                 </div>
+                 <svg id="graph-svg"></svg>
+                 <div id="tooltip"></div>
+            </div>
+        </div>
+
+    </div>
+
+
+    <script>
+        document.addEventListener('DOMContentLoaded', () => {{
+            // --- DOM Element References ---
+            const fileInput = document.getElementById('fileInput');
+            const analyzeBtn = document.getElementById('analyzeBtn');
+            const weightThresholdInput = document.getElementById('weightThreshold');
+            const tooltip = d3.select("#tooltip");
+            const placeholder = document.getElementById('placeholder');
+            const graphControls = document.getElementById('graph-controls');
+
+            // UI elements for summary data
+            const totalNodesEl = document.getElementById('total-nodes');
+            const totalEdgesEl = document.getElementById('total-edges');
+            const totalSwitchesEl = document.getElementById('total-switches');
+
+            // --- State Variables ---
+            let fullGraphData = {{ nodes: [], links: [] }};
+            let simulation; // To hold the D3 simulation
+
+            // --- Event Listeners ---
+            analyzeBtn.addEventListener('click', handleAnalysis);
+            weightThresholdInput.addEventListener('input', () => drawGraph()); // Redraw on threshold change
+
+            /**
+             * Handles the file reading, parsing, and initial graph drawing.
+             */
+            function handleAnalysis() {{
+                const file = fileInput.files[0];
+                if (!file) {{
+                    console.warn('No file selected.');
+                    fileInput.focus();
+                    return;
+                }}
+
+                placeholder.textContent = 'Analyzing...';
+                placeholder.style.display = 'flex';
+                document.getElementById('graph-svg').innerHTML = '';
+
+                if (simulation) simulation.stop(); // Stop any previous simulation
+
+                const reader = new FileReader();
+                reader.onload = (event) => {{
+                    const text = event.target.result;
+                    fullGraphData = parseSchedData(text);
+                    if (fullGraphData.nodes.length > 0) {{
+                        placeholder.style.display = 'none';
+                        graphControls.classList.remove('hidden');
+                        graphControls.classList.add('flex');
+
+                        updateMetrics(fullGraphData);
+                        drawGraph();
+                    }} else {{
+                        placeholder.textContent = 'Could not parse data from file. Please check the format.';
+                    }}
+                }};
+                reader.onerror = (error) => {{
+                    placeholder.textContent = 'Error reading file.';
+                    console.error('Error reading file:', error);
+                }};
+                reader.readAsText(file);
+            }}
+
+            /**
+             * Updates the metric cards with data from the analysis.
+             */
+            function updateMetrics({{nodes, links}}) {{
+                totalNodesEl.textContent = nodes.length.toLocaleString();
+                totalEdgesEl.textContent = links.length.toLocaleString();
+                const totalSwitches = links.reduce((sum, link) => sum + link.weight, 0);
+                totalSwitchesEl.textContent = totalSwitches.toLocaleString();
+            }}
+
+            /**
+             * Parses the raw scheduler trace data from the text file.
+             */
+            function parseSchedData(text) {{
+                const lines = text.split('
+');
+                const nodeMap = new Map();
+                const linkMap = new Map();
+                const regex = /prev_comm=([\S]+)\s+prev_pid=\d+\s+prev_tid=([\S]+)[\s\S]*?==>\s+next_comm=([\S]+)\s+next_tid=([\S]+)/;
+
+                for (const line of lines) {{
+                    const match = line.match(regex);
+                    if (match) {{
+                        const [, prev_comm, prev_tid, next_comm, next_tid] = match;
+                        const sourceId = `${prev_comm}/${prev_tid}`;
+                        const targetId = `${next_comm}/${next_tid}`;
+
+                        if (sourceId === targetId) continue;
+
+                        if (!nodeMap.has(sourceId)) nodeMap.set(sourceId, {{ id: sourceId }});
+                        if (!nodeMap.has(targetId)) nodeMap.set(targetId, {{ id: targetId }});
+
+                        const linkKey = [sourceId, targetId].sort().join('--');
+
+                        if (linkMap.has(linkKey)) {{
+                            linkMap.get(linkKey).weight++;
+                        }} else {{
+                            linkMap.set(linkKey, {{
+                                source: sourceId,
+                                target: targetId,
+                                weight: 1
+                            }});
+                        }}
+                    }}
+                }}
+
+                return {{
+                    nodes: Array.from(nodeMap.values()),
+                    links: Array.from(linkMap.values())
+                }};
+            }}
+
+            /**
+             * Draws or updates the graph based on the current threshold.
+             */
+            function drawGraph() {{
+                if (!fullGraphData.nodes || fullGraphData.nodes.length === 0) return;
+
+                const threshold = +weightThresholdInput.value;
+                const {{ nodes, links }} = fullGraphData;
+
+                const filteredLinks = links.filter(link => link.weight >= threshold);
+                const maxWeight = d3.max(links, d => d.weight) || 1;
+
+                const container = document.getElementById('graph-container');
+                const svg = d3.select("#graph-svg");
+
+                svg.selectAll("*").remove();
+
+                const width = container.clientWidth;
+                const height = container.clientHeight;
+
+                const g = svg.append("g");
+
+                // --- D3 Simulation Setup ---
+                simulation = d3.forceSimulation(nodes)
+                    .force("link", d3.forceLink(links).id(d => d.id)
+                        .strength(d => 0.1 * Math.sqrt(d.weight / maxWeight)))
+                    .force("charge", d3.forceManyBody().strength(-400))
+                    .force("center", d3.forceCenter(width / 2, height / 2))
+                    .force("collide", d3.forceCollide().radius(15));
+
+                // --- Draw Links (Grouped Line + Text) ---
+                const linkGroup = g.append("g")
+                    .selectAll("g")
+                    .data(filteredLinks)
+                    .join("g")
+                    .attr("class", "link-group");
+
+                linkGroup.append("line")
+                    .attr("stroke", "#999")
+                    .attr("stroke-opacity", 0.6)
+                    .attr("stroke-width", d => Math.min(Math.sqrt(d.weight), 8) * 0.5 + 0.5);
+
+                linkGroup.append("text")
+                    .text(d => d.weight)
+                    .attr("font-size", "10px")
+                    .attr("font-family", "sans-serif")
+                    .attr("fill", "#333")
+                    .attr("stroke", "white")
+                    .attr("stroke-width", 0.4)
+                    .attr("paint-order", "stroke")
+                    .style("display", "none") // Hide text by default
+                    .style("pointer-events", "none");
+
+                linkGroup
+                    .on("mouseover", function(event, d) {{
+                        d3.select(this).select('text').style('display', 'block'); // Show text on hover
+                        tooltip.style("opacity", 1).html(`切换次数: ${d.weight}`);
+                    }})
+                    .on("mousemove", (event) => {{
+                         tooltip.style("left", (event.pageX + 15) + "px")
+                                .style("top", (event.pageY - 28) + "px");
+                    }})
+                    .on("mouseout", function() {{
+                        d3.select(this).select('text').style('display', 'none'); // Hide text on mouseout
+                        tooltip.style("opacity", 0);
+                    }});
+
+
+                // --- Draw Nodes (Grouped Circle + Text) ---
+                const nodeGroup = g.append("g")
+                    .selectAll("g")
+                    .data(nodes)
+                    .join("g")
+                    .attr("class", "node");
+
+                nodeGroup.append("circle")
+                    .attr("r", 8)
+                    .attr("fill", "#4f46e5")
+                    .attr("stroke", "#fff")
+                    .attr("stroke-width", 1.5);
+
+                nodeGroup.append("text")
+                    .text(d => d.id)
+                    .attr("x", 12)
+                    .attr("y", 4)
+                    .attr("font-size", "12px")
+                    .attr("font-family", "monospace")
+                    .attr("fill", "#333")
+                    .style("display", "none") // Hidden by default
+                    .style("pointer-events", "none");
+
+                // --- Interaction Handlers on the Node Group ---
+                nodeGroup.on("mouseover", function(event, d) {{
+                        d3.select(this).select('text').style('display', 'block');
+                        tooltip.style("opacity", 1).html(`任务: ${d.id}`);
+                    }})
+                    .on("mousemove", (event) => {{
+                        tooltip.style("left", (event.pageX + 15) + "px")
+                               .style("top", (event.pageY - 28) + "px");
+                    }})
+                    .on("mouseout", function() {{
+                        d3.select(this).select('text').style('display', 'none');
+                        tooltip.style("opacity", 0);
+                    }});
+
+                // --- Drag and Zoom Handlers ---
+                const drag = d3.drag()
+                    .on("start", (event, d) => {{
+                        if (!event.active) simulation.alphaTarget(0.3).restart();
+                        d.fx = d.x;
+                        d.fy = d.y;
+                    }})
+                    .on("drag", (event, d) => {{
+                        d.fx = event.x;
+                        d.fy = event.y;
+                    }})
+                    .on("end", (event, d) => {{
+                        if (!event.active) simulation.alphaTarget(0);
+                        d.fx = null;
+                        d.fy = null;
+                    }});
+
+                nodeGroup.call(drag);
+
+                const zoom = d3.zoom()
+                    .scaleExtent([0.1, 10])
+                    .on("zoom", (event) => {{
+                        g.attr("transform", event.transform);
+                    }});
+
+                svg.call(zoom);
+
+                // --- Simulation Ticker ---
+                simulation.on("tick", () => {{
+                    linkGroup.select("line")
+                        .attr("x1", d => d.source.x)
+                        .attr("y1", d => d.source.y)
+                        .attr("x2", d => d.target.x)
+                        .attr("y2", d => d.target.y);
+
+                    linkGroup.select("text")
+                        .attr("x", d => (d.source.x + d.target.x) / 2)
+                        .attr("y", d => (d.source.y + d.target.y) / 2);
+
+                    nodeGroup.attr("transform", d => `translate(${d.x},${d.y})`);
+                }});
+            }});
+    </script>
+
+</body>
+</html>


### PR DESCRIPTION
This commit introduces a main portal page and restructures the LiteWebServer application to serve its functionalities as modules accessible from this portal.

Key changes:

1.  **Main Portal Page (`main_portal.html`):**
    *   Added a new main portal page served at the root URL (`/`). This page acts as a central hub linking to various tools and functionalities.
    *   The content for this page was provided by you and includes links to external resources as well as internal tools.

2.  **Scheduler Graph Page (`scheduler_graph.html`):**
    *   Added a new static HTML page for "调度关系力导向图" (Scheduler Trace Visualizer).
    *   This page is served at `/scheduler_graph_tool/` and linked from the main portal.

3.  **DFX File Browser Restructuring:**
    *   The existing file browser functionality (previously at the root) is now served under the `/browse/` path (e.g., `/browse/`, `/browse/<subpath>`).
    *   It is linked from the "DFX 平台数据文件浏览器" card on the main portal.
    *   All associated file operations (upload, download, create folder, search) and internal redirects have been updated to function correctly under this new base path, primarily through the robust use of `url_for`.

4.  **Route Updates (`litewebserver.py`):**
    *   The Flask routing table was modified to reflect these changes, directing `/` to the main portal, `/browse/` to the file browser, and `/scheduler_graph_tool/` to the new scheduler graph page.

Links on the main portal for the DFX Browser and Scheduler Graph tool now use `url_for` for better maintainability. The JavaScript on the main portal ensures all links open in new tabs.