### PR TITLE
Fix: Resolve Jinja2 TemplateSyntaxError in scheduler_graph.html script

### DIFF
--- a/litewebserver/templates/scheduler_graph.html
+++ b/litewebserver/templates/scheduler_graph.html
@@ -117,7 +117,7 @@
 
     </div>
 
-
+{% raw %}
     <script>
         document.addEventListener('DOMContentLoaded', () => {{
             // --- DOM Element References ---
@@ -380,6 +380,7 @@
                 }});
             }});
     </script>
+{% endraw %}
 
 </body>
 </html>


### PR DESCRIPTION
A `jinja2.exceptions.TemplateSyntaxError: unexpected '//'` was occurring in `litewebserver/templates/scheduler_graph.html` within an inline JavaScript `<script>` block. This was caused by Jinja2 attempting to parse JavaScript comments.

This commit fixes the error by wrapping the identified inline `<script>` block(s) in `scheduler_graph.html` with `{% raw %}` and `{% endraw %}` tags. This instructs Jinja2 to treat the content within these tags as raw text.

This addresses the last known instance of Jinja2 misinterpreting CSS or JavaScript content in your project's HTML templates.