### PR TITLE
Add 'Transfer' button and functionality to data browser

### DIFF
--- a/litewebserver/templates/data_brower.html
+++ b/litewebserver/templates/data_brower.html
@@ -115,6 +115,8 @@
                 <td>
                     {% if item.type == 'file' %}
                         <a href="{{ url_for('download_file', filepath=item.path) }}" download>Download</a>
+                        &nbsp; <!-- Add a space for separation -->
+                        <button onclick="transferFile('{{ item.path }}')">Transfer</button>
                     {% endif %}
                 </td>
             </tr>
@@ -179,6 +181,51 @@
             console.error('Search input or table body not found for search functionality.');
         }
     });
+
+    function transferFile(filepath) {
+        if (!filepath) {
+            alert('Error: Filepath is missing.');
+            return;
+        }
+        console.log('Attempting to transfer file:', filepath); // For debugging
+
+        // Optional: Disable button or show loading state here
+
+        fetch(`/transfer/${filepath}`, {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json' // Optional: if sending JSON body, not needed for empty body
+            }
+            // body: JSON.stringify({ filepath: filepath }) // Optional: if server expects filepath in body
+        })
+        .then(response => {
+            if (!response.ok) {
+                // Try to get error message from server response
+                return response.json().then(err => {
+                    throw new Error(err.message || `HTTP error! status: ${response.status}`);
+                }).catch(() => {
+                    // If response is not JSON or no message, throw generic error
+                    throw new Error(`HTTP error! status: ${response.status}`);
+                });
+            }
+            return response.json();
+        })
+        .then(data => {
+            if (data.status === 'success') {
+                alert(`File transferred successfully. New file: ${data.new_file}`);
+                location.reload(); // Refresh the page to show the new file
+            } else {
+                alert(`Error transferring file: ${data.message}`);
+            }
+        })
+        .catch(error => {
+            console.error('Error during transfer operation:', error);
+            alert(`An error occurred: ${error.message}`);
+        })
+        .finally(() => {
+            // Optional: Re-enable button or hide loading state here
+        });
+    }
 </script>
 </body>
 </html>


### PR DESCRIPTION
This commit introduces a new 'Transfer' button in the data browser interface. This button allows you to transform a selected file using the `trace_streamer` tool on the server.

Key changes:

- Modified `litewebserver/templates/data_brower.html`:
    - Added a 'Transfer' button next to the 'Download' link for each file.
    - Implemented a JavaScript function `transferFile(filepath)` that:
        - Sends a POST request to a new `/transfer/<filepath>` endpoint.
        - Displays success or error messages to you. - Reloads the page upon successful transfer.

- Modified `litewebserver/litewebserver.py`:
    - Added a new Flask route `@app.route('/transfer/<path:filepath>', methods=['POST'])`.
    - The `transfer_file(filepath)` function handles the server-side logic:
        - Validates the file path and ensures it's within the served directory.
        - Constructs the output filename (e.g., `original.txt` -> `original.db`). - Executes the command `trace_streamer <input_file> -e <output_file.db>`. - Returns JSON responses indicating success (with the new filename) or failure (with error details).
    - Added `subprocess` import and used `app.logger` for server-side logging.

The `trace_streamer` command is expected to be in the system's PATH. Both the original file and the newly created `.db` file are preserved on the server. Manual testing is required to fully verify the `trace_streamer` integration and error handling under various conditions.