### PR TITLE
FEAT: Update button labels and add Visual Analysis link

### DIFF
--- a/litewebserver/templates/data_brower.html
+++ b/litewebserver/templates/data_brower.html
@@ -114,10 +114,14 @@
                 <td>{{ item.last_modified if item.last_modified is not none else '-' }}</td>
                 <td>
                     {% if item.type == 'file' %}
-                        <a href="{{ url_for('download_file', filepath=item.path) }}" download>Download</a>
+                        <a href="{{ url_for('download_file', filepath=item.path) }}" download>下载</a>
                         {% if item.name.endswith('.data') or item.name.endswith('.txt') %}
-                            &nbsp; <!-- Add a space for separation -->
-                            <button onclick="transferFile('{{ item.path }}')">Transfer</button>
+                            &nbsp;
+                            <button onclick="transferFile('{{ item.path }}')">格式转换</button>
+                        {% endif %}
+                        {% if item.name.endswith('.data') or item.name.endswith('.txt') or item.name.endswith('.db') %}
+                            &nbsp;
+                            <a href="https://rtosdfx.rnd.com/application/?trace={{ url_for('download_file', filepath=item.path, _external=True) }}&link=true" target="_blank">可视分析</a>
                         {% endif %}
                     {% endif %}
                 </td>


### PR DESCRIPTION
This commit introduces several UI enhancements to the data browser:

- Button labels have been updated to Chinese:
    - "Download" is now "下载".
    - "Transfer" is now "格式转换".

- A new "可视分析" (Visual Analysis) button/link has been added to the Actions column.
    - This link is displayed conditionally for files with `.data`, `.txt`, or `.db` extensions.
    - It points to an external application URL: `https://rtosdfx.rnd.com/application/`
    - The URL includes a `trace` parameter which is the full, absolute download URL for the selected file (generated using `url_for` with `_external=True`).
    - The link also includes the `link=true` parameter.
    - The link opens in a new browser tab (`target="_blank"`).

These changes improve your experience by providing localized text and direct access to a visual analysis tool for relevant file types.