### PR TITLE
fix: Remove stray comment from HTML

### DIFF
--- a/litewebserver/templates/scheduler_graph.html
+++ b/litewebserver/templates/scheduler_graph.html
@@ -184,7 +184,7 @@
                     </div>
                     <span class="text-gray-400 mx-1">|</span>
                     
-                    <div class="flex items-center ml-2"> {/* Adjusted ml-2 from ml-4 for consistent spacing with new separators */}
+                    <div class="flex items-center ml-2">
                         <span class="text-xs font-medium text-gray-600">颜色图例:</span>
                         <div class="flex ml-2">
                             <div class="flex items-center mr-3">


### PR DESCRIPTION
Removes an unintentional developer comment that was visible in the UI next to the color legend.