### PR TITLE
refactor: Compact and rearrange controls in right-hand card

### DIFF
--- a/litewebserver/templates/scheduler_graph.html
+++ b/litewebserver/templates/scheduler_graph.html
@@ -187,16 +187,11 @@
             </div>
 
             <div class="metric-card lg:w-1/4 table-container p-3"> {/* Added padding to the card */}
-                <div class="flex justify-end items-center mb-2"> {/* Changed justify-between to justify-end since title is gone */}
-                    {/* Title removed */}
-                    <button id="resetFilterBtn" class="px-4 py-1.5 bg-gray-200 text-gray-700 text-sm font-medium rounded-lg shadow-sm hover:bg-gray-300 focus:outline-none focus:ring-2 focus:ring-gray-500 focus:ring-opacity-75">
-                       <i class="fa fa-refresh mr-1"></i>Reset Filter
-                    </button>
-                </div>
-                <div class="flex flex-col space-y-3 mb-3 mt-3 border-t pt-3"> {/* Wrapper for the moved controls, added mt-3, border-t, pt-3 for separation */}
+                <div class="flex flex-row items-center justify-between space-x-2 mb-2 pt-1 border-t mt-2"> {/* Single row for controls */}
+                    {/* BFS Depth (compact) */}
                     <div class="flex items-center">
-                        <label for="bfsDepthSelect" class="text-sm font-medium text-gray-700 whitespace-nowrap mr-2">BFS深度:</label>
-                        <select id="bfsDepthSelect" class="p-1.5 rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm w-full"> {/* Made select full width */}
+                        <label for="bfsDepthSelect" class="text-xs font-medium text-gray-600 mr-1 whitespace-nowrap">BFS:</label>
+                        <select id="bfsDepthSelect" class="p-1 text-xs rounded border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500" style="min-width: 45px; max-width:55px;">
                             <option value="1">1</option>
                             <option value="2">2</option>
                             <option value="3">3</option>
@@ -209,21 +204,23 @@
                             <option value="10">10</option>
                         </select>
                     </div>
-                    <div class="flex flex-col space-y-1"> {/* Changed to flex-col for legend items stacking */}
-                        <span class="text-xs font-medium text-gray-600">颜色图例:</span>
-                        <div class="flex items-center">
-                            <div class="depth-level bg-orange-400"></div>
-                            <span class="text-xs text-gray-600">源节点</span>
+                    {/* Color Legend (compact and horizontal) */}
+                    <div class="flex items-center space-x-1">
+                        <span class="text-xs font-medium text-gray-600 hidden sm:inline">Legend:</span> {/* Hide "Legend:" on very small screens if needed */}
+                        <div class="flex items-center" title="Source Node">
+                            <div class="depth-level bg-orange-400 w-2.5 h-2.5"></div> <span class="text-xs text-gray-500 ml-0.5 hidden md:inline">S</span>
                         </div>
-                        <div class="flex items-center">
-                            <div class="depth-level bg-yellow-400"></div>
-                            <span class="text-xs text-gray-600">1级节点</span>
+                        <div class="flex items-center" title="Level 1">
+                            <div class="depth-level bg-yellow-400 w-2.5 h-2.5"></div> <span class="text-xs text-gray-500 ml-0.5 hidden md:inline">L1</span>
                         </div>
-                        <div class="flex items-center">
-                            <div class="depth-level bg-green-400"></div>
-                            <span class="text-xs text-gray-600">2+级节点</span>
+                        <div class="flex items-center" title="Level 2+">
+                            <div class="depth-level bg-green-400 w-2.5 h-2.5"></div> <span class="text-xs text-gray-500 ml-0.5 hidden md:inline">L2+</span>
                         </div>
                     </div>
+                    {/* Reset Button (compact) */}
+                    <button id="resetFilterBtn" class="px-2 py-1 bg-gray-200 text-gray-700 text-xs font-medium rounded shadow-sm hover:bg-gray-300 whitespace-nowrap">
+                       Reset
+                    </button>
                 </div>
                 <div class="overflow-x-auto">
                     <table id="links-table" class="w-full text-xs text-left text-gray-500 compact-table">


### PR DESCRIPTION
Implements layout changes for the controls within the right-hand card (containing the links table) to enhance compactness:

-   **Single-Line Layout:** BFS Depth selector, Color Legend, and the
    Reset button are now arranged on a single horizontal line.
-   **BFS Depth Control:**
    -   Label shortened to "BFS:".
    -   Select dropdown width significantly reduced and padding/font
        size decreased.
-   **Color Legend:**
    -   Redesigned for horizontal compactness.
    -   Main "Legend:" label can be hidden on very small screens.
    -   Individual legend item texts (e.g., "Source", "Level 1") are
        abbreviated (S, L1, L2+) and can be hidden on small to medium
        screens, with full descriptions available via tooltips (title attributes).
    -   Color swatches are made smaller.
-   **Reset Button:**
    -   Renamed from "Reset Filter" to "Reset".
    *   Button padding and font size reduced for a smaller footprint.