### PR TITLE
fix: Resolve graph rendering failure by correcting JS scope issue

### DIFF
--- a/litewebserver/templates/scheduler_graph.html
+++ b/litewebserver/templates/scheduler_graph.html
@@ -571,11 +571,15 @@
                 const svg = d3.select("#graph-svg");
 
                 // Store last transform if available
-                if (g && d3.zoomTransform(svg.node()) !== d3.zoomIdentity) {
-                    lastZoomTransform = d3.zoomTransform(svg.node());
+                // Check if svg.node() exists and is zoomable before getting transform
+                if (svg.node() && typeof d3.zoomTransform === 'function' && svg.node().__zoom !== undefined && svg.node().__zoom !== d3.zoomIdentity) {
+                     if (g) { // Ensure global g was previously defined (e.g. from a previous draw)
+                        lastZoomTransform = d3.zoomTransform(svg.node());
+                     }
                 }
 
-                svg.selectAll("*").remove(); // This removes 'g' as well
+
+                svg.selectAll("*").remove(); // This removes 'g' as well if it was part of svg's children
 
                 // Update displayed node and edge counts based on the data *before* simulation
                 // These are the nodes and links that will be attempted to be rendered.
@@ -592,7 +596,7 @@
                 const width = container.clientWidth;
                 const height = container.clientHeight;
 
-                const g = svg.append("g");
+                g = svg.append("g"); // Assign to the higher-scoped 'g'
 
                 if (isDirected) {
                     svg.append("defs").append("marker")


### PR DESCRIPTION
This commit addresses a bug that prevented the D3 graph from rendering. While investigating issues related to D3 force parameter tuning, a JavaScript scoping error was identified as the primary cause of the rendering failure.

The SVG group element 'g' for the graph was being declared locally within the `drawGraph` function, while the D3 zoom handler and transform restoration logic were attempting to reference a global 'g' variable that remained undefined. This resulted in runtime errors, halting graph rendering and interaction.

This fix corrects the scope of the 'g' variable, ensuring that the zoom and transform operations target the correct SVG group. The D3 force parameters, as previously tuned and intended by a recent commit (dynamic link strength, charge force -500, collision radius 22 with strength 0.7), remain in effect and should now function correctly.

Additionally, a minor robustness improvement was added for accessing the `lastZoomTransform` to prevent potential errors.