### PR TITLE
fix: Improve fullscreen API handling for restricted environments

### DIFF
--- a/litewebserver/templates/scheduler_graph.html
+++ b/litewebserver/templates/scheduler_graph.html
@@ -1136,11 +1136,26 @@
             }
 
             // Fullscreen API handling
+            function isFullscreenApiAvailable() {
+                return document.fullscreenEnabled ||
+                       document.mozFullScreenEnabled ||
+                       document.webkitFullscreenEnabled ||
+                       document.msFullscreenEnabled || false;
+            }
+
             function toggleFullscreen() {
-                if (!document.fullscreenElement &&
-                    !document.mozFullScreenElement &&
-                    !document.webkitFullscreenElement &&
-                    !document.msFullscreenElement) { // Not in fullscreen
+                const isCurrentlyFullscreen = document.fullscreenElement ||
+                                            document.mozFullScreenElement ||
+                                            document.webkitFullscreenElement ||
+                                            document.msFullscreenElement;
+
+                if (!isCurrentlyFullscreen) { // Not in fullscreen, try to enter
+                    if (!isFullscreenApiAvailable()) {
+                        console.warn("Fullscreen API is not available or not allowed in this context (e.g., missing iframe 'allowfullscreen' attribute).");
+                        alert("Fullscreen mode is not available or not allowed in this environment."); // Optional: alert user
+                        return;
+                    }
+
                     if (graphContainer.requestFullscreen) {
                         graphContainer.requestFullscreen();
                     } else if (graphContainer.mozRequestFullScreen) { /* Firefox */
@@ -1150,7 +1165,7 @@
                     } else if (graphContainer.msRequestFullscreen) { /* IE/Edge */
                         graphContainer.msRequestFullscreen();
                     }
-                } else { // In fullscreen
+                } else { // In fullscreen, try to exit
                     if (document.exitFullscreen) {
                         document.exitFullscreen();
                     } else if (document.mozCancelFullScreen) { /* Firefox */


### PR DESCRIPTION
This commit updates the Fullscreen API JavaScript logic in `scheduler_graph.html`.

Changes:
- Added a helper function `isFullscreenApiAvailable()` that checks `document.fullscreenEnabled` and its vendor-prefixed versions.
- The `toggleFullscreen()` function now calls `isFullscreenApiAvailable()` before attempting to request fullscreen.
- If the API is unavailable or disallowed (e.g., due to iframe restrictions in environments like Jupyter), a warning is logged to the console, and an alert is displayed to the user. This provides graceful degradation and clearer feedback.

This change does not directly enable fullscreen in environments that restrict it at the iframe level (like Jupyter without `allowfullscreen` on its iframes) but improves the user experience by making the failure more informative.